### PR TITLE
Add restart link to final Twine passage

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ Grandma moves a little bit the sheet showing her eyes.
 
 [[Where is grandma??]]</tw-passagedata><tw-passagedata pid="21" name="Where is grandma??" tags="" position="400,1375" size="100,100">The woodchopper then looked in the closet and found Little Red Riding Hood&#39;s grandmother. She was not eaten! She had hidden in the closet when she saw the wolf. Everyone was safe, and Little Red Riding Hood promised to always listen to her mother and never, ever talk to strangers again.
 
-&#39;&#39;END&#39;&#39;</tw-passagedata><tw-passagedata pid="22" name="Swing the stick at the wolf" tags="" position="275,1250" size="100,100">You swing the stick with all your strength and hit the wolf&#39;s nose! He yelps in surprise and stumbles back for a second hitting against the windows of the house.
+&#39;&#39;END&#39;&#39; [[Restart|Beginning]]</tw-passagedata><tw-passagedata pid="22" name="Swing the stick at the wolf" tags="" position="275,1250" size="100,100">You swing the stick with all your strength and hit the wolf&#39;s nose! He yelps in surprise and stumbles back for a second hitting against the windows of the house.
 
 [[Continue|The woodchopper arrives]]</tw-passagedata><tw-passagedata pid="23" name="The woodchopper arrives" tags="" position="275,1375" size="100,100">Just then, a woodchopper was walking by the house. He heard a noise comming from the old granma&#39;s house. Then, the woodchopper saw the big, bad wolf hitting against one of the windows. He opened the front door with a kick.
 


### PR DESCRIPTION
## Summary
- Add a Twine restart link to the final "Where is grandma??" passage, allowing the story to restart at the "Beginning".

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f86c346988322a8d49afe4ad83796