### PR TITLE
Add custom Twine styles for readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,28 @@
 </head>
 <body>
 <tw-story><noscript><tw-noscript>JavaScript needs to be enabled to play The Little Red Ridding Hood.</tw-noscript></noscript></tw-story>
-<tw-storydata name="The Little Red Ridding Hood" startnode="1" creator="Twine" creator-version="2.10.0" format="Harlowe" format-version="3.3.9" ifid="B7C4C00A-8880-4A5D-B1B1-0F58F91A3C02" options="" tags="" zoom="1" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Beginning" tags="" position="275,250" size="100,100">(set: $haStick to false)
+<tw-storydata name="The Little Red Ridding Hood" startnode="1" creator="Twine" creator-version="2.10.0" format="Harlowe" format-version="3.3.9" ifid="B7C4C00A-8880-4A5D-B1B1-0F58F91A3C02" options="" tags="" zoom="1" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">
+body {
+  background-color: #fdf6f0;
+  color: #2c2c2c;
+  font-family: "Georgia", "Times New Roman", serif;
+  line-height: 1.6;
+}
+
+ tw-link, a {
+  color: #b22222;
+  text-decoration: none;
+  background-color: #ffe6e6;
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-weight: bold;
+}
+
+ tw-link:hover, a:hover {
+  background-color: #ffcccc;
+  color: #4b0000;
+}
+</style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Beginning" tags="" position="275,250" size="100,100">(set: $haStick to false)
 Little Red Riding Hood is on her way to her grandmother&#39;s house. Her mother has warned her to stay on the path and not talk to strangers.   As she walks through the woods, she comes to a fork in the path. What should she do?
 [[Stay on the main path, which is long and safe]]
 [[Take the dark path.|Go down the small, dark path, which is shorter]]


### PR DESCRIPTION
## Summary
- Improve readability with warm background, dark text, and serif fonts in user stylesheet
- Highlight interactive links with button-like styling and hover states

## Testing
- `w3m -dump index.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689f86bf148883228f7743b01dcdcdd8