### PR TITLE
Fix typo in image path for 5.png

### DIFF
--- a/The Little Red Riding Hood Local Images.html
+++ b/The Little Red Riding Hood Local Images.html
@@ -207,7 +207,7 @@ The Little Red Riding Hood found a stick on the ground. She decided to pick it u
 [[She goes to pick the flowers for her grandmother.]] 
 
 
-</tw-passagedata><tw-passagedata pid="7" name="She talks to the wolf and tells him where she is going" tags="" position="150,500" size="100,100">&lt;img src=&quot;imnages/5.png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
+</tw-passagedata><tw-passagedata pid="7" name="She talks to the wolf and tells him where she is going" tags="" position="150,500" size="100,100">&lt;img src=&quot;images/5.png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
 The wolf told Little Red Riding Hood, &quot;I know a faster way to your grandmother&#39;s house.&quot; He pointed to a small, hidden trail. &quot;Follow this path, and I will meet you there. It&#39;s a special shortcut.&quot;
 
 What should Little Red Riding Hood do?

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@ The Little Red Riding Hood found a stick on the ground. She decided to pick it u
 [[She goes to pick the flowers for her grandmother.]] 
 
 
-</tw-passagedata><tw-passagedata pid="7" name="She talks to the wolf and tells him where she is going" tags="" position="150,500" size="100,100">&lt;img src=&quot;imnages/5.png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
+</tw-passagedata><tw-passagedata pid="7" name="She talks to the wolf and tells him where she is going" tags="" position="150,500" size="100,100">&lt;img src=&quot;images/5.png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
 The wolf told Little Red Riding Hood, &quot;I know a faster way to your grandmother&#39;s house.&quot; He pointed to a small, hidden trail. &quot;Follow this path, and I will meet you there. It&#39;s a special shortcut.&quot;
 
 What should Little Red Riding Hood do?


### PR DESCRIPTION
## Summary
- Correct typos in image path for 5.png in index and local images HTML files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7be82b52883228a29721f54ffb1f5