### PR TITLE
Gate stick attack option behind stick possession

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,11 +249,12 @@ Grandma moves a little bit the sheet showing her eyes.
 [[Grandmother, what big teeth you have!]]
 [[Do not say anything.]]</tw-passagedata><tw-passagedata pid="17" name="Grandmother, what big teeth you have!" tags="" position="400,1125" size="100,100">&quot;All the better to EAT you with!&quot; the wolf roared. He jumped out of the bed, a big, hungry smile on his face. Little Red Riding Hood screamed and ran out of the house.
 &lt;img src=&quot;images/ChatGPT Image 15 ago 2025, 08_28_16 p.m..png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
-(if: $hasStick is true)[
+(if: $hasstick)[
   [[Swing the stick at the wolf]]
-](else-if: $hasrock is true)[
+](else-if: $hasrock)[
   [[Throw the stone to the wolf]]
 ](else:)[
+  No tienes nada con qué defenderte.
   [[Scream]]
   [[Ask for help]]
 ]</tw-passagedata><tw-passagedata pid="18" name="Do not say anything." tags="" position="525,1125" size="100,100">[[Grandmother, what big teeth you have!]] </tw-passagedata><tw-passagedata pid="19" name="Ask for help" tags="" position="525,1250" size="100,100">Just then, a woodchopper was walking by the house. He heard Little Red Riding Hood&#39;s asking for help and ran inside. The woodchopper saw the big, bad wolf. He quickly pulled out his axe and chased the wolf away. The wolf ran into the forest and was never seen again.


### PR DESCRIPTION
## Summary
- Show "Swing the stick at the wolf" only when the player has picked up the stick
- Display warning text and alternate choices when the player lacks a weapon

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c53028148322b3bbc56ae8a09d59