### PR TITLE
Add restart, save, and load story menu options

### DIFF
--- a/The Little Red Riding Hood Local Images.html
+++ b/The Little Red Riding Hood Local Images.html
@@ -258,7 +258,7 @@ Grandma moves a little bit the sheet showing her eyes.
   [[Ask for help]]
 ]</tw-passagedata><tw-passagedata pid="18" name="Do not say anything." tags="" position="525,1125" size="100,100">[[Grandmother, what big teeth you have!]] </tw-passagedata><tw-passagedata pid="19" name="Ask for help" tags="" position="525,1250" size="100,100">Just then, a woodchopper was walking by the house. He heard Little Red Riding Hood&#39;s asking for help and ran inside. The woodchopper saw the big, bad wolf. He quickly pulled out his axe and chased the wolf away. The wolf ran into the forest and was never seen again.
 &lt;img src=&quot;images/woodchopper (1).png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
-[[Where is grandma??]] </tw-passagedata><tw-passagedata pid="20" name="Scream" tags="" position="400,1250" size="100,100">Just then, a woodchopper was walking by the house. He heard Little Red Riding Hood&#39;s screams and ran inside. The woodchopper saw the big, bad wolf. He quickly pulled out his axe and chased the wolf away. The wolf ran into the forest and was never seen again.
+[[Where is grandma??]] (display: "inventory")</tw-passagedata><tw-passagedata pid="20" name="Scream" tags="" position="400,1250" size="100,100">Just then, a woodchopper was walking by the house. He heard Little Red Riding Hood&#39;s screams and ran inside. The woodchopper saw the big, bad wolf. He quickly pulled out his axe and chased the wolf away. The wolf ran into the forest and was never seen again.
 &lt;img src=&quot;images/woodchopper (1).png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
 [[Where is grandma??]]</tw-passagedata><tw-passagedata pid="21" name="Where is grandma??" tags="" position="400,1375" size="100,100">The woodchopper then looked in the closet and found Little Red Riding Hood&#39;s grandmother. She was not eaten! She had hidden in the closet when she saw the wolf. Everyone was safe, and Little Red Riding Hood promised to always listen to her mother and never, ever talk to strangers again.
 &lt;img src=&quot;images/the end.png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
@@ -273,7 +273,11 @@ Grandma moves a little bit the sheet showing her eyes.
 </tw-passagedata><tw-passagedata pid="24" name="Chasing the wolf away" tags="" position="275,1500" size="100,100">When he enters, the big bad wolf was jumpin over the the little red riding hood. He quickly pulled out his axe and chased the wolf away. The wolf ran into the forest and was never seen again.
 &lt;img src=&quot;images/chasing the wolf away.png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
 
-[[Where is grandma??]] </tw-passagedata><tw-passagedata pid="25" name="startup" tags="" position="100,175" size="100,100">&lt;img src=&quot;https://www.science.org/do/10.1126/article.23922/full/sn-redridinghood-1644923258497.jpg&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
+[[Where is grandma??]] (display: "inventory")</tw-passagedata><tw-passagedata pid="25" name="startup" tags="" position="100,175" size="100,100">
+(storymenu: "Reiniciar", (restart:))
+(storymenu: "Guardar partida", (save-game: "slot1"))
+(storymenu: "Cargar partida", (load-game: "slot1"))
+&lt;img src=&quot;https://www.science.org/do/10.1126/article.23922/full/sn-redridinghood-1644923258497.jpg&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
 (link: &quot;Beginning&quot;)[
   (track: &#39;theme&#39;, &#39;loop&#39;, true)
   (track: &#39;theme&#39;, &#39;play&#39;)

--- a/index.html
+++ b/index.html
@@ -275,7 +275,11 @@ Grandma moves a little bit the sheet showing her eyes.
 (display: "inventory")</tw-passagedata><tw-passagedata pid="24" name="Chasing the wolf away" tags="" position="275,1500" size="100,100">When he enters, the big bad wolf was jumpin over the the little red riding hood. He quickly pulled out his axe and chased the wolf away. The wolf ran into the forest and was never seen again.
 &lt;img src=&quot;images/chasing the wolf away.png&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
 
-[[Where is grandma??]] (display: "inventory")</tw-passagedata><tw-passagedata pid="25" name="startup" tags="" position="100,175" size="100,100">&lt;img src=&quot;https://www.science.org/do/10.1126/article.23922/full/sn-redridinghood-1644923258497.jpg&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
+[[Where is grandma??]] (display: "inventory")</tw-passagedata><tw-passagedata pid="25" name="startup" tags="" position="100,175" size="100,100">
+(storymenu: "Reiniciar", (restart:))
+(storymenu: "Guardar partida", (save-game: "slot1"))
+(storymenu: "Cargar partida", (load-game: "slot1"))
+&lt;img src=&quot;https://www.science.org/do/10.1126/article.23922/full/sn-redridinghood-1644923258497.jpg&quot; width=&quot;300&quot; height=&quot;400&quot; alt=&quot;Descripción&quot; class=&quot;flotante&quot;/&gt;
 (link: &quot;Beginning&quot;)[
   (track: &#39;theme&#39;, &#39;loop&#39;, true)
   (track: &#39;theme&#39;, &#39;play&#39;)


### PR DESCRIPTION
## Summary
- Add restart, save, and load controls to the startup passage
- Preserve inventory display before startup

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c769468883229d33039fd72dacf9