### PR TITLE
Fix blank page by including jQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@ She grabbed the stone and threw it to the wolf with all her strenght.
 [[Continue|The woodchopper arrives]](display: "inventory")</tw-passagedata><tw-passagedata pid="31" name="inventory" tags="startup" position="0,0" size="100,100">(replace: ?inventory)[(if: $hasStick)[🏒 Palo]]</tw-passagedata></tw-storydata>
 
 
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load jQuery from CDN before existing script to resolve missing dependency that caused blank page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d77c8748832291add096355babb5